### PR TITLE
修正作者与仓库信息不正确的问题

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "authors": [
         {
             "name": "ele",
-            "link": "https://github.com/elegantland/qqMessageBlocker"
+            "link": "https://github.com/elegantland"
         }
     ],
     "platform": [
@@ -23,7 +23,7 @@
         "preload": "./src/preload.js"
     },
     "repository": {
-        "repo": "elegantloneland/qqMessageBlocker",
+        "repo": "elegantland/qqMessageBlocker",
         "branch": "main"
       }
 }


### PR DESCRIPTION
作者链接应该指向个人资料页而不是仓库
`repo`才该写仓库链接。

> 结果作者链接变成了仓库链接,仓库链接指向了不存在的作者。